### PR TITLE
remove tags and references to tags

### DIFF
--- a/Prefabs/CroquetBridge.prefab
+++ b/Prefabs/CroquetBridge.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 5552111265146463839}
   m_Layer: 0
   m_Name: CroquetBridge
-  m_TagString: Bridge
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -47,12 +47,24 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   appProperties: {fileID: 11400000, guid: d8a4c352ae9b743efa34611f46d63ff2, type: 2}
   appName: 
-  builderPath: 
+  defaultSessionName: 123
   useNodeJS: 0
-  croquetSessionReady: 0
-  showRigidbodyStateHighlight: 0
-  localAvatarId: 
-  cameraOwnerId: 
+  debugLoggingFlags:
+    session: 0
+    messages: 0
+    sends: 0
+    snapshot: 0
+    data: 0
+    hashing: 0
+    subscribe: 0
+    classes: 0
+    ticks: 0
+  sessionRunning: 0
+  sessionName: 0
+  croquetViewId: 
+  croquetViewCount: 0
+  triggerGlitchNow: 0
+  glitchDuration: 3
 --- !u!114 &5552111265146463839
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -66,4 +78,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitForUserLaunch: 0
+  localReflector: 
   showWebview: 0

--- a/Scripts/Runtime/Core/CroquetBuilder.cs
+++ b/Scripts/Runtime/Core/CroquetBuilder.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEditor;
 using Debug = UnityEngine.Debug;
+using Object = UnityEngine.Object;
 
 public class CroquetBuilder
 {
@@ -44,15 +45,13 @@ public class CroquetBuilder
         CroquetBridge bridgeComp = null;
         CroquetRunner runnerComp = null;
         GameObject[] roots = scene.GetRootGameObjects();
-        // we assume that the bridge has the tag Bridge (presumably faster than trying
-        // GetComponent() on every object)
-        // ...but note that this doesn't guarantee that it has, specifically, a
-        // CroquetBridge component.
-        GameObject bridge = Array.Find<GameObject>(roots, o => o.CompareTag("Bridge"));
+        
+        CroquetBridge bridge = Object.FindObjectOfType<CroquetBridge>();
+        
         if (bridge != null)
         {
-            bridgeComp = bridge.GetComponent<CroquetBridge>();
-            runnerComp = bridge.GetComponent<CroquetRunner>();
+            bridgeComp = bridge;
+            runnerComp = bridge.gameObject.GetComponent<CroquetRunner>();
         }
 
         sceneName = scene.name;


### PR DESCRIPTION
because tags are a project level setting lets keep it for the user to use, and remove it from the package. 

A user wanting an easy reference to bridge information should be able to (in the future) access it in the same way, or an easier way like Croquet.the-thing-that-you-need