### PR TITLE
customize index.js

### DIFF
--- a/.JSTools/.gitignore
+++ b/.JSTools/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/.JSTools/build-tools/sources/unity-bridge.js
+++ b/.JSTools/build-tools/sources/unity-bridge.js
@@ -1055,6 +1055,7 @@ export const PM_GameAvatar = superclass => class extends superclass {
     constructor(actor) {
         super(actor);
         this.componentNames.add('CroquetAvatarComponent');
+        this.extraWatched.add('driver');
         this.onDriverSet();
         this.listenOnce("driverSet", this.onDriverSet);
     }

--- a/.JSTools/build-tools/sources/unity-bridge.js
+++ b/.JSTools/build-tools/sources/unity-bridge.js
@@ -10,7 +10,7 @@
 //   \x05 to mark the start of the data argument in a binary-encoded message, such as updateSpatial.
 
 
-import { ModelService, Actor, RegisterMixin, mix, Pawn, View, ViewRoot, ViewService, GetViewService, StartWorldcore, PawnManager, v3_equals, q_equals } from "@croquet/worldcore-kernel";
+import { ModelService, Actor, RegisterMixin, mix, Pawn, View, ViewRoot, ViewService, GetViewService, StartWorldcore, PawnManager, v3_equals, q_equals, q_normalize } from "@croquet/worldcore-kernel";
 
 globalThis.timedLog = msg => {
     // timing on the message itself is now added when forwarding
@@ -500,8 +500,10 @@ export class InitializationManager extends ModelService {
                         props.translation = value.split(',').map(Number); // note name change
                         break;
                     case 'rotation':
+                        props.rotation = q_normalize(value.split(',').map(Number));
+                        break;
                     case 'scale':
-                        props[propName] = value.split(',').map(Number);
+                        props.scale = value.split(',').map(Number);
                         break;
                     default:
                         props[propName] = value;

--- a/.JSTools/build-tools/webpack.config.js
+++ b/.JSTools/build-tools/webpack.config.js
@@ -6,12 +6,30 @@ const HtmlWebPackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
 module.exports = env => ({
-    entry : `./sources/${env.buildTarget === 'node' ? 'index-node.tmp.js' : 'index.tmp.js'}`,
+    entry: () => {
+        // if custom index-node.js exists in the app directory, use it
+        if (env.buildTarget === 'node') {
+            try {
+                const index = `../${env.appName}/index-node.js`;
+                require.resolve(index);
+                return index;
+            } catch (e) {/* fall through and try index.js next */}
+        }
+        // if custom index.js exists in the app directory, use it
+        try {
+            const index = `../${env.appName}/index.js`;
+            require.resolve(index);
+            return index;
+        } catch (e) {
+            // otherwise, use the default index.tmp.js
+            return `./sources/${env.buildTarget === 'node' ? 'index-node.tmp.js' : 'index.tmp.js'}`;
+        }
+    },
     output: {
         path: path.join(__dirname, `../../StreamingAssets/${env.appName}/`),
         pathinfo: false,
-        filename: env.buildTarget === 'node' ? 'node-main.js' : '[name]-[contenthash:8].js',
-        chunkFilename: env.buildTarget === 'node' ? 'node-chunk.js' : 'chunk-[name]-[contenthash:8].js',
+        filename: env.buildTarget === 'node' ? 'node-main.js' : 'index-[contenthash:8].js',
+        chunkFilename: 'chunk-[contenthash:8].js',
         clean: true
     },
     cache: {

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+!.JSTools

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.js text eol=lf

--- a/Prefabs/CroquetBridge.prefab
+++ b/Prefabs/CroquetBridge.prefab
@@ -46,9 +46,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   appProperties: {fileID: 11400000, guid: d8a4c352ae9b743efa34611f46d63ff2, type: 2}
-  appName: 
-  defaultSessionName: 123
   useNodeJS: 0
+  appName: 
+  defaultSessionName: 
+  launchThroughMenu: 0
+  firstLevelScene: 
   debugLoggingFlags:
     session: 0
     messages: 0
@@ -59,12 +61,16 @@ MonoBehaviour:
     subscribe: 0
     classes: 0
     ticks: 0
-  sessionRunning: 0
-  sessionName: 0
+  croquetSessionState: stopped
+  sessionName: 
   croquetViewId: 
   croquetViewCount: 0
+  croquetActiveScene: 
+  croquetActiveSceneState: 
+  unitySceneState: preparing
   triggerGlitchNow: 0
   glitchDuration: 3
+  croquetSystems: []
 --- !u!114 &5552111265146463839
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Prefabs/CroquetBridge.prefab
+++ b/Prefabs/CroquetBridge.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 5552111265146463839}
   m_Layer: 0
   m_Name: CroquetBridge
-  m_TagString: Bridge
+  m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -47,12 +47,24 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   appProperties: {fileID: 11400000, guid: d8a4c352ae9b743efa34611f46d63ff2, type: 2}
   appName: 
-  builderPath: 
+  defaultSessionName: 123
   useNodeJS: 0
-  croquetSessionReady: 0
-  showRigidbodyStateHighlight: 0
-  localAvatarId: 
-  cameraOwnerId: 
+  debugLoggingFlags:
+    session: 0
+    messages: 0
+    sends: 0
+    snapshot: 0
+    data: 0
+    hashing: 0
+    subscribe: 0
+    classes: 0
+    ticks: 0
+  sessionRunning: 0
+  sessionName: 0
+  croquetViewId: 
+  croquetViewCount: 0
+  triggerGlitchNow: 0
+  glitchDuration: 3
 --- !u!114 &5552111265146463839
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -66,4 +78,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   waitForUserLaunch: 0
+  localReflector: 
   showWebview: 0

--- a/Scripts/Editor/CroquetMenu.cs
+++ b/Scripts/Editor/CroquetMenu.cs
@@ -45,13 +45,10 @@ public static class SceneAndPlayWatcher
 
     private static void HandlePlayModeState(PlayModeStateChange state)
     {
-        //if (state == PlayModeStateChange.ExitingEditMode)
-        //{
-        //    CroquetBuilder.EnteringPlayMode();
-        //}
+        // PlayModeStateChange.ExitingEditMode (i.e., entering Play) is handled above in the constructor
         if (state == PlayModeStateChange.EnteredEditMode)
         {
-            CroquetBuilder.EnteredPlayMode();
+            CroquetBuilder.EnteredEditMode();
         }
     }
 
@@ -102,7 +99,7 @@ public class CroquetMenu
         // this item is not available if either
         //   we don't know how to build for the current scene, or
         //   a watcher for any scene is running (MacOS only), or
-        //   a build has been requested and hasn't finished yet 
+        //   a build has been requested and hasn't finished yet
         if (!CroquetBuilder.KnowHowToBuildJS()) return false;
 
 #if !UNITY_EDITOR_WIN

--- a/Scripts/Runtime/Components/CroquetActorManifest.cs
+++ b/Scripts/Runtime/Components/CroquetActorManifest.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class CroquetActorManifest : MonoBehaviour
 {
+    public string pawnType = "";
+    public string defaultActorClass = ""; // only used on pre-load objects
     public string[] mixins;
     public string[] staticProperties;
     public string[] watchedProperties;

--- a/Scripts/Runtime/Components/CroquetComponent.cs
+++ b/Scripts/Runtime/Components/CroquetComponent.cs
@@ -9,7 +9,7 @@ public abstract class CroquetComponent : MonoBehaviour
     void Awake()
     {
         // if (croquetSystem == null) Debug.Log($"futile attempt to awaken {this}");
-        croquetSystem.RegisterComponent(this);
+        if (croquetSystem != null) croquetSystem.RegisterComponent(this);
     }
 
 }

--- a/Scripts/Runtime/Components/CroquetEntityComponent.cs
+++ b/Scripts/Runtime/Components/CroquetEntityComponent.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 public class CroquetEntityComponent : CroquetComponent
 {
     public override CroquetSystem croquetSystem { get; set; } = CroquetEntitySystem.Instance;
-    
+
     public string croquetActorId = ""; // the actor identifier (M###)
     public string croquetHandle = ""; // unique integer ID as a string (agreed Unique across bridge)
     // specify the accompanying actor class here

--- a/Scripts/Runtime/Components/CroquetSpatialComponent.cs
+++ b/Scripts/Runtime/Components/CroquetSpatialComponent.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using UnityEngine;
 
 [AddComponentMenu("Croquet/SpatialComponent")]
+[SelectionBase]
 public class CroquetSpatialComponent : CroquetComponent
 {
     public override CroquetSystem croquetSystem { get; set; } = CroquetSpatialSystem.Instance;
@@ -15,22 +16,24 @@ public class CroquetSpatialComponent : CroquetComponent
     public Quaternion rotation = Quaternion.identity ;
     public Vector3 scale = Vector3.one;
 
-    [Header("Options")]
-    public bool initializeWithSceneTransform = false;
-    [Space(10)]
-    public float positionDeltaEpsilon = 0.01f;
-    public float rotationDeltaEpsilon = 0.01f;
-    public float scaleDeltaEpsilon = 0.01f;
-    [Space(10)]
+    [Header("OPTIONS")]
+    public bool includeOnSceneInit = true;
+    [Space(5)]
+    [Header("Smoothing")]
     public float positionSmoothTime = 0.25f; // used by SmoothDamp
-    public Vector3 dampedVelocity = Vector3.zero; // used by SmoothDamp
-    public float rotationLerpFactor = 0.2f;
-    public float scaleLerpFactor = 0.2f;
-
+    public float positionEpsilon = 0.01f;
+    [HideInInspector] public Vector3 dampedVelocity = Vector3.zero; // used by SmoothDamp
+    [Space(5)]
+    public float rotationLerpPerFrame = 0.2f;
+    public float rotationEpsilon = 0.01f;
+    [Space(5)]
+    public float scaleLerpPerFrame = 0.2f;
+    public float scaleEpsilon = 0.01f;
+    [Space(5)]
     [Header("Ballistic motion")]
     public float desiredLag = 0.05f; // seconds behind
-    public float currentLag = 0f;
-    public Vector3? ballisticVelocity = null;
+    [HideInInspector] public float currentLag = 0f;
+    [HideInInspector] public Vector3? ballisticVelocity = null;
     public float ballisticNudgeLerp = 0.2f; // adjustments to "ballistic" movement
 
     // public List<string> telemetry = new List<string>(); // for testing

--- a/Scripts/Runtime/Components/CroquetSpatialComponent.cs
+++ b/Scripts/Runtime/Components/CroquetSpatialComponent.cs
@@ -16,9 +16,13 @@ public class CroquetSpatialComponent : CroquetComponent
     public Quaternion rotation = Quaternion.identity ;
     public Vector3 scale = Vector3.one;
 
+    [Header("SCENE LAYOUT")]
+    public int positionMaxDecimals = 4;
+    public int rotationMaxDecimals = 6;
+    public int scaleMaxDecimals = 4;
+
     [Header("OPTIONS")]
     public bool includeOnSceneInit = true;
-    [Space(5)]
     [Header("Smoothing")]
     public float positionSmoothTime = 0.25f; // used by SmoothDamp
     public float positionEpsilon = 0.01f;

--- a/Scripts/Runtime/Core/Croquet.cs
+++ b/Scripts/Runtime/Core/Croquet.cs
@@ -1,6 +1,8 @@
 using System;
 using UnityEngine;
 using System.Collections.Generic;
+using System.IO;
+using UnityEngine.SceneManagement;
 
 public static class Croquet
 {
@@ -357,6 +359,11 @@ public static class Croquet
 
     #region Actor Property Access
 
+    public static bool HasActorSentProperty(GameObject gameObject, string propertyName)
+    {
+        return CroquetEntitySystem.Instance.HasActorSentProperty(gameObject, propertyName);
+    }
+
     public static string ReadActorString(GameObject gameObject, string propertyName)
     {
         string stringVal = CroquetEntitySystem.Instance.GetPropertyValueString(gameObject, propertyName);
@@ -403,6 +410,35 @@ public static class Croquet
         // during game startup (at least until the Croquet session has started) this
         // will return the default value -1f.
         return CroquetBridge.Instance.CroquetSessionTime();
+    }
+
+    public static void RequestToLoadScene(int sceneBuildIndex, bool forceReload)
+    {
+        string path = SceneUtility.GetScenePathByBuildIndex(sceneBuildIndex);
+        if (path == "")
+        {
+            Debug.LogError($"Failed to find scene with buildIndex {sceneBuildIndex}");
+            return;
+        }
+
+        string filename = Path.GetFileNameWithoutExtension(path);
+        if (filename == "")
+        {
+            Debug.LogError($"Failed to parse scene-file name for buildIndex {sceneBuildIndex} from {path}");
+            return;
+        }
+
+        RequestToLoadScene(filename, forceReload, false); // don't normally force a rebuild
+    }
+
+    public static void RequestToLoadScene(string sceneName, bool forceReload)
+    {
+        RequestToLoadScene(sceneName, forceReload, false); // don't normally force a rebuild
+    }
+
+    public static void RequestToLoadScene(string sceneName, bool forceReload, bool forceRebuild)
+    {
+        CroquetBridge.Instance.RequestToLoadScene(sceneName, forceReload, forceRebuild);
     }
 }
 

--- a/Scripts/Runtime/Core/Croquet.cs
+++ b/Scripts/Runtime/Core/Croquet.cs
@@ -414,6 +414,11 @@ public static class Croquet
 
     public static void RequestToLoadScene(int sceneBuildIndex, bool forceReload)
     {
+        RequestToLoadScene(sceneBuildIndex, forceReload, false); // don't normally force a rebuild
+    }
+
+    public static void RequestToLoadScene(int sceneBuildIndex, bool forceReload, bool forceRebuild)
+    {
         string path = SceneUtility.GetScenePathByBuildIndex(sceneBuildIndex);
         if (path == "")
         {
@@ -428,7 +433,7 @@ public static class Croquet
             return;
         }
 
-        RequestToLoadScene(filename, forceReload, false); // don't normally force a rebuild
+        RequestToLoadScene(filename, forceReload, forceRebuild);
     }
 
     public static void RequestToLoadScene(string sceneName, bool forceReload)

--- a/Scripts/Runtime/Core/CroquetBuilder.cs
+++ b/Scripts/Runtime/Core/CroquetBuilder.cs
@@ -45,9 +45,9 @@ public class CroquetBuilder
         CroquetBridge bridgeComp = null;
         CroquetRunner runnerComp = null;
         GameObject[] roots = scene.GetRootGameObjects();
-        
+
         CroquetBridge bridge = Object.FindObjectOfType<CroquetBridge>();
-        
+
         if (bridge != null)
         {
             bridgeComp = bridge;
@@ -351,9 +351,9 @@ public class CroquetBuilder
         }
     }
 
-    public static void EnteredPlayMode()
+    public static void EnteredEditMode()
     {
-        // if there is a watcher, re-establish the process reporting its logs
+        // if there is a watcher, when play stops re-establish the process reporting its logs
         string logFile = EditorPrefs.GetString(LOG_PROP, "");
         if (logFile != "")
         {

--- a/Scripts/Runtime/Core/CroquetBuilder.cs
+++ b/Scripts/Runtime/Core/CroquetBuilder.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEditor;
 using Debug = UnityEngine.Debug;
+using Object = UnityEngine.Object;
 
 public class CroquetBuilder
 {
@@ -44,15 +45,13 @@ public class CroquetBuilder
         CroquetBridge bridgeComp = null;
         CroquetRunner runnerComp = null;
         GameObject[] roots = scene.GetRootGameObjects();
-        // we assume that the bridge has the tag Bridge (presumably faster than trying
-        // GetComponent() on every object)
-        // ...but note that this doesn't guarantee that it has, specifically, a
-        // CroquetBridge component.
-        GameObject bridge = Array.Find<GameObject>(roots, o => o.CompareTag("Bridge"));
+        
+        CroquetBridge bridge = Object.FindObjectOfType<CroquetBridge>();
+        
         if (bridge != null)
         {
-            bridgeComp = bridge.GetComponent<CroquetBridge>();
-            runnerComp = bridge.GetComponent<CroquetRunner>();
+            bridgeComp = bridge;
+            runnerComp = bridge.gameObject.GetComponent<CroquetRunner>();
         }
 
         sceneName = scene.name;

--- a/Scripts/Runtime/Core/CroquetRunner.cs
+++ b/Scripts/Runtime/Core/CroquetRunner.cs
@@ -21,7 +21,7 @@ public class CroquetRunner : MonoBehaviour
     private static string bridgeSourcePath; // croquet-bridge folder under StreamingAssets
     private static string appSourcePath; // app's own folder under StreamingAssets
     private static string nodeExecPath = ""; // provided by CroquetBridge
-    
+
     struct CroquetNodeProcess : IJob
     {
         public int port;
@@ -46,7 +46,7 @@ public class CroquetRunner : MonoBehaviour
             croquetProcess.StartInfo.CreateNoWindow = true;
 
             string nodeEntry = "node-main.js";
-            
+
             croquetProcess.StartInfo.FileName = nodeExecPath;
             croquetProcess.StartInfo.Arguments = $"{nodeEntry} {port}";
 
@@ -88,7 +88,7 @@ public class CroquetRunner : MonoBehaviour
             }
         }
     }
-    
+
     public IEnumerator StartCroquetConnection(int port, string appName, bool useNodeJS, string pathToNode)
     {
         bridgeSourcePath = Path.Combine(Application.streamingAssetsPath, "croquet-bridge");
@@ -116,7 +116,7 @@ public class CroquetRunner : MonoBehaviour
         //
         //   deployed standalone on Windows:
         //     i. nodeJS (using node.exe copied into StreamingAssets)
-        
+
         // figure out the web url, whatever is going to happen
         // Use the port number determined by the bridge
         string webURL = $"http://localhost:{port}/{appName}/index.html";
@@ -132,6 +132,7 @@ public class CroquetRunner : MonoBehaviour
         {
             // cases (a), (h)
             WebViewObject webViewObject = (new GameObject("WebViewObject")).AddComponent<WebViewObject>();
+            DontDestroyOnLoad(webViewObject.gameObject);
             webViewObject.Init(
                 separated: showWebview,
                 enableWKWebView: true,
@@ -185,14 +186,14 @@ public class CroquetRunner : MonoBehaviour
             // cases (b), (g)
             TimedLog($"ready for browser to load from {webURL}");
         }
-        
+
         if (useNodeJS)
         {
             if (!waitForUserLaunch)
             {
                 // cases (c), (e), (i)
                 nodeExecPath = pathToNode;
-                
+
                 var job = new CroquetNodeProcess()
                 {
                     port = port

--- a/Scripts/Runtime/Systems/CroquetSpatialSystem.cs
+++ b/Scripts/Runtime/Systems/CroquetSpatialSystem.cs
@@ -353,7 +353,7 @@ public class CroquetSpatialSystem : CroquetSystem
 
         if (scale != null)
         {
-            argList.Add("p");
+            argList.Add("s");
             argList.Add(string.Join<float>(",", new[] { scale.Value.x, scale.Value.y, scale.Value.z }));
         }
 

--- a/Scripts/Runtime/Systems/CroquetSystem.cs
+++ b/Scripts/Runtime/Systems/CroquetSystem.cs
@@ -17,6 +17,7 @@ public abstract class CroquetSystem : MonoBehaviour
 
     public virtual void RegisterComponent(CroquetComponent component)
     {
+        // Debug.Log($"register {component.gameObject} in {this}");
         components.Add(component.gameObject.GetInstanceID(), component);
     }
 
@@ -40,11 +41,6 @@ public abstract class CroquetSystem : MonoBehaviour
         // by default, nothing
     }
 
-    public virtual void TearDownSession()
-    {
-        // by default, nothing
-    }
-
     public virtual void ProcessCommand(string command, string[] args)
     {
         throw new NotImplementedException();
@@ -55,9 +51,41 @@ public abstract class CroquetSystem : MonoBehaviour
         throw new NotImplementedException();
     }
 
-    //TODO: implement
-    //public abstract void OnSessionDisconnect();
+    public virtual void LoadedScene(string sceneName)
+    {
+        // by default, nothing
+    }
 
+    public virtual bool ReadyToRunScene(string sceneName)
+    {
+        return true;
+    }
 
+    public virtual void ClearSceneBeforeRunning()
+    {
+        components.Clear(); // wipe out anything that registered as the scene came up
+    }
+
+    public virtual void TearDownScene()
+    {
+        // by default, just clear the components
+        components.Clear();
+    }
+
+    public virtual void TearDownSession()
+    {
+        // by default, just invoke TearDownScene
+        TearDownScene();
+    }
+
+    public virtual string InitializationStringForObject(GameObject go)
+    {
+        return "";
+    }
+
+    public virtual List<string> InitializationStringsForObject(GameObject go)
+    {
+        return new List<string>();
+    }
 
 }

--- a/Scripts/Runtime/Utility/PresentOncePositionUpdated.cs
+++ b/Scripts/Runtime/Utility/PresentOncePositionUpdated.cs
@@ -6,18 +6,21 @@ using UnityEngine;
 public class PresentOncePositionUpdated : MonoBehaviour
 {
     public bool waitUntilMove = false;
+    public float timeout = 0.1f; // present after this time even if not moved
     private CroquetSpatialComponent sc;
-    
+    private float startTime;
+
     private void Start()
     {
         sc = GetComponent<CroquetSpatialComponent>();
+        startTime = Time.realtimeSinceStartup;
     }
 
     private void Update()
     {
         // or
         // if(CroquetSpatialSystem.Instance.hasObjectMoved(gameObject.GetInstanceID()))
-        if (sc.hasBeenMoved || (!waitUntilMove && sc.hasBeenPlaced))
+        if (sc.hasBeenMoved || (!waitUntilMove && sc.hasBeenPlaced) || Time.realtimeSinceStartup - startTime >= timeout)
         {
             foreach (var renderer in GetComponentsInChildren<MeshRenderer>())
             {

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,8 @@
 
 This repo contains all Croquet functionality as a unitypackage ready to be dropped into a new project. This is for starting your own project. For usage examples please see our tutorials or other demo repos.
 
-NOTE: IF YOU HAVE NOT EXPLICITLY BEEN PERMITTED INTO THE CROQUET FOR UNITY BETA, THIS REPO IS STILL AVAILABLE FOR YOU TO HACK AROUND WITH. THERE IS NO GUARANTEE THAT FEATURES WILL NOT INTRODUCE BREAKING CHANGES, UNTIL WE REACH A 1.0 RELEASE. WE WILL BEGIN ADMITTING SMALL BATCHES OF DEVELOPERS INTO THE BETA, AT WHICH POINT WE WILL PROVIDE SUPPORT FOR THOSE DEVELOPERS IN OUR DISCORD.
-If you believe yourself to have a critical need to be in the early beta participants, and can accept that major changes are in progress, please DM Lazarus#7304 via the Croquet Discord.
+# Questions
+Please feel free to ask questions on our [discord](https://croquet.io/discord).
 
 
 # Setup
@@ -25,7 +25,7 @@ TODO: Link sample gitignore files (for Unity and Croquet general files)
 #### WebSocket
 If you do not already have NuGet installed, add this to the package manager:
 ```
-https://github.com/GlitchEnzo/NuGetForUnity
+https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity
 ```
 Then use the NuGet Menu item to search for and install `WebSocketSharp-netstandard`
 
@@ -122,11 +122,12 @@ Select it and click "Make this the active input map"
 
 Skip this step if you want to use your own completely custom set of input events.
 
-# Usage
-
 
 # Contribution
+Contributions to the project are welcome as these projects are open source and we encourage community involvement.
 
-
-# License
+1. Base your `feature/my-feature-name` branch off of `develop` branch
+2. Make your changes
+3. Open a PR against the `develop` branch
+4. Discuss and Review the PR with the team
 


### PR DESCRIPTION
This allows to override the built-in templates for `index.js` by providing an `index.js` (and optionally `index-node.js`) in the app directory. 

If those files exists, they will be used, otherwise the current mechanism via `index.generic.js` and `index.tmp.js` is used.