### PR TITLE
generalize webpack.config.js to allow custom overrides of index.js

### DIFF
--- a/.JSTools/build-tools/webpack.config.js
+++ b/.JSTools/build-tools/webpack.config.js
@@ -6,12 +6,30 @@ const HtmlWebPackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
 module.exports = env => ({
-    entry : `./sources/${env.buildTarget === 'node' ? 'index-node.tmp.js' : 'index.tmp.js'}`,
+    entry: () => {
+        // if custom index-node.js exists in the app directory, use it
+        if (env.buildTarget === 'node') {
+            try {
+                const index = `../${env.appName}/index-node.js`;
+                require.resolve(index);
+                return index;
+            } catch (e) {/* fall through and try index.js next */}
+        }
+        // if custom index.js exists in the app directory, use it
+        try {
+            const index = `../${env.appName}/index.js`;
+            require.resolve(index);
+            return index;
+        } catch (e) {
+            // otherwise, use the default index.tmp.js
+            return `./sources/${env.buildTarget === 'node' ? 'index-node.tmp.js' : 'index.tmp.js'}`;
+        }
+    },
     output: {
         path: path.join(__dirname, `../../StreamingAssets/${env.appName}/`),
         pathinfo: false,
-        filename: env.buildTarget === 'node' ? 'node-main.js' : '[name]-[contenthash:8].js',
-        chunkFilename: env.buildTarget === 'node' ? 'node-chunk.js' : 'chunk-[name]-[contenthash:8].js',
+        filename: env.buildTarget === 'node' ? 'node-main.js' : 'index-[contenthash:8].js',
+        chunkFilename: 'chunk-[contenthash:8].js',
         clean: true
     },
     cache: {


### PR DESCRIPTION
This allows to override the built-in templates for `index.js` by providing an `index.js` (and optionally `index-node.js`) in the app directory.

If those files exists, they will be used, otherwise the current mechanism via `index.generic.js` and `index.tmp.js` is used.