### PR TITLE
Feature/node flag

### DIFF
--- a/Scripts/Runtime/Core/CroquetBridge.cs
+++ b/Scripts/Runtime/Core/CroquetBridge.cs
@@ -20,7 +20,7 @@ public class CroquetBridge : MonoBehaviour
     public CroquetSettings appProperties;
 
     [Header("Session Configuration")]
-    public bool useNodeJS;
+    public bool forceToUseNodeJS = false;
     public string appName;
     public string defaultSessionName = "ABCDE";
     public string launchViaMenuIntoScene = "";
@@ -366,14 +366,22 @@ public class CroquetBridge : MonoBehaviour
 
         Log("session", $"started HTTP/WS Server on port {port}");
 
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-        string pathToNode = appProperties.pathToNode; // doesn't exist on Windows
+        string pathToNode = "";
+        bool useNodeJS;
+
+#if UNITY_EDITOR_OSX
+        pathToNode = appProperties.pathToNode; // if needed
+        useNodeJS = forceToUseNodeJS; // up to the user
 #elif UNITY_EDITOR_WIN
-        string pathToNode = CroquetBuilder.NodeExeInPackage;
+        // in Windows editor, use Node unless user has set waitForUserLaunch and has *not* set forceToUseNodeJS
+        pathToNode = CroquetBuilder.NodeExeInPackage; // if needed
+        useNodeJS = !(croquetRunner.waitForUserLaunch && !forceToUseNodeJS);
 #elif UNITY_STANDALONE_WIN || UNITY_WSA
-        string pathToNode = CroquetBuilder.NodeExeInBuild;
+        pathToNode = CroquetBuilder.NodeExeInBuild;
+        useNodeJS = true;
 #else
-        string pathToNode = ""; // not available
+        // some form of non-Windows standalone.  Node is not available.
+        useNodeJS = false;
 #endif
 
         StartCoroutine(croquetRunner.StartCroquetConnection(port, appName, useNodeJS, pathToNode));

--- a/Scripts/Runtime/Core/CroquetBridge.cs
+++ b/Scripts/Runtime/Core/CroquetBridge.cs
@@ -20,7 +20,6 @@ public class CroquetBridge : MonoBehaviour
     public CroquetSettings appProperties;
 
     [Header("Session Configuration")]
-    public bool forceToUseNodeJS = false;
     public string appName;
     public string defaultSessionName = "ABCDE";
     public string launchViaMenuIntoScene = "";
@@ -367,11 +366,11 @@ public class CroquetBridge : MonoBehaviour
         Log("session", $"started HTTP/WS Server on port {port}");
 
         string pathToNode = "";
-        bool useNodeJS;
+        bool forceToUseJS = croquetRunner.forceToUseNodeJS;
+        bool useNodeJS = forceToUseJS; // default
 
 #if UNITY_EDITOR_OSX
         pathToNode = appProperties.pathToNode; // if needed
-        useNodeJS = forceToUseNodeJS; // up to the user
 #elif UNITY_EDITOR_WIN
         // in Windows editor, use Node unless user has set waitForUserLaunch and has *not* set forceToUseNodeJS
         pathToNode = CroquetBuilder.NodeExeInPackage; // if needed

--- a/Scripts/Runtime/Core/CroquetBuilder.cs
+++ b/Scripts/Runtime/Core/CroquetBuilder.cs
@@ -163,11 +163,6 @@ public class CroquetBuilder
             goodToGo = false;
         }
 
-        if (sceneBridgeComponent.forceToUseNodeJS && !buildForWindows)
-        {
-            Debug.LogWarning($"Croquet Bridge component's \"Force to Use Node JS\" is checked, but must be off for a non-Windows build");
-            goodToGo = false;
-        };
         if (sceneBridgeComponent.debugForceSceneRebuild)
         {
             Debug.LogWarning("Croquet Bridge component's \"Debug Force Scene Rebuild\" must be off");
@@ -176,6 +171,11 @@ public class CroquetBuilder
         if (sceneRunnerComponent.waitForUserLaunch)
         {
             Debug.LogWarning("Croquet Runner component's \"Wait For User Launch\" must be off");
+            goodToGo = false;
+        };
+        if (sceneRunnerComponent.forceToUseNodeJS && !buildForWindows)
+        {
+            Debug.LogWarning($"Croquet Runner component's \"Force to Use Node JS\" is checked, but must be off for a non-Windows build");
             goodToGo = false;
         };
         if (sceneRunnerComponent.runOffline)
@@ -281,15 +281,15 @@ public class CroquetBuilder
             // for Windows, we include a version of node.exe in the package.
             // it can be used for JS building, for running scenes in the editor,
             // and for inclusion in a Windows standalone build.
-            bool useNodeJS;
+            bool forceToUseNodeJS = sceneRunnerComponent.forceToUseNodeJS;
+            bool useNodeJS = forceToUseNodeJS; // default
 #if !UNITY_EDITOR_WIN
             string pathToNode = sceneBridgeComponent.appProperties.pathToNode;
-            useNodeJS = sceneBridgeComponent.forceToUseNodeJS; // up to the user
 #else
             // we're in a Windows editor
             string pathToNode = NodeExeInPackage;
             // build using Node unless user has set waitForUserLaunch and has *not* set forceToUseNodeJS
-            useNodeJS = !(sceneRunnerComponent.waitForUserLaunch && !sceneBridgeComponent.forceToUseNodeJS);
+            useNodeJS = !(sceneRunnerComponent.waitForUserLaunch && !forceToUseNodeJS);
 #endif
             return new JSBuildDetails(sceneBridgeComponent.appName, useNodeJS, pathToNode);
         }

--- a/Scripts/Runtime/Core/CroquetRunner.cs
+++ b/Scripts/Runtime/Core/CroquetRunner.cs
@@ -15,6 +15,7 @@ using Debug = UnityEngine.Debug;
 public class CroquetRunner : MonoBehaviour
 {
     public bool waitForUserLaunch;
+    public bool forceToUseNodeJS = false;
     public bool runOffline;
     public string localReflector;
 #if UNITY_EDITOR_WIN


### PR DESCRIPTION
Our handling of the "useNodeJS" flag on CroquetBridge has always been weird, in that on Windows - as a convenience - we would automatically reach in and set it to true when entering play.  Correct outcome, but probably disconcerting for the user.

Also weird (and a historical accident) that this setting was on the Croquet Bridge rather than the Croquet Runner, even though the latter is the component responsible for launching Croquet.

Providing instead a "forceToUseNodeJS" setting, on the runner, leaves us free (if it isn't set) to default to Node on Windows and Webview everywhere else, without having to mess with what the user had selected.

We'll still have to explain that if you set "waitForUserLaunch" but have *not* set "forceToUseNodeJS", C4U will assume that you want to run with a browser rather than node, even on Windows.  But that's a debugging situation, and we do tell people that the normal way to debug is with a browser.  You can force Node in this situation too if you want.

This change will require careful update of the documentation.